### PR TITLE
fix: Add newline after ssh_ca_public_key

### DIFF
--- a/modules/kairos-k3s-cluster/templates/user-data/stages/initramfs.yaml.tftpl
+++ b/modules/kairos-k3s-cluster/templates/user-data/stages/initramfs.yaml.tftpl
@@ -76,8 +76,8 @@ initramfs:
       - path: /etc/ssh/trusted_users_ca.pub
         permissions: 0644
         content: |
-          ${ssh_ca_public_key~}
-      %{~ if length(ssh_admin_principals) > 0 }
+          ${ssh_ca_public_key}
+      %{~ if length(ssh_admin_principals) > 0 ~}
       - path: /etc/ssh/auth_principals/kairos
         permissions: 0555
         content: |+


### PR DESCRIPTION
Without this, there is no newline before the next key which leads to the files being borked
